### PR TITLE
Release v1.1.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-integration",
   "name": "GitHub Copilot Integration",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "minAppVersion": "0.15.0",
   "description": "Integrate GitHub Copilot for AI-powered text generation and assistance.",
   "author": "go2engle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-copilot-integration",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "GitHub Copilot Integration for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,13 @@ const DEFAULT_ACTIONS: CopilotAction[] = [
     replaceSelection: true,
   },
   {
+    name: 'Generate code',
+    icon: '💻',
+    system: 'You are an AI assistant that follows instruction extremely well. Help as much as you can.',
+    prompt: 'Based on the following text, generate code that accomplishes what is described. Wrap all code output in a fenced Markdown code block with the appropriate language identifier. Only output the code block, no additional explanation.',
+    replaceSelection: false,
+  },
+  {
     name: 'Plan',
     icon: '🧠',
     system: 'You are an AI assistant that follows instruction extremely well. Help as much as you can.',


### PR DESCRIPTION
## Summary

- **Old version:** 1.1.1 → **New version:** 1.1.2 (patch)

## Changes since last version bump

- Add new built-in "Generate code" action (💻) that takes highlighted text and generates code in a fenced Markdown code block with the appropriate language identifier
- Add manual trigger (`workflow_dispatch`) to release workflow
- Replace version-change detection with tag-exists check for more reliable releases
- Fix shell interpolation of PR body in release workflow by passing as env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)