### PR TITLE
Release v1.3.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-copilot-integration",
   "name": "GitHub Copilot Integration",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "minAppVersion": "0.15.0",
   "description": "Integrate GitHub Copilot for AI-powered text generation and assistance.",
   "author": "go2engle",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-copilot-integration",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GitHub Copilot Integration for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/src/inlineDiffView.ts
+++ b/src/inlineDiffView.ts
@@ -1,0 +1,188 @@
+import { StateEffect, StateField, RangeSetBuilder } from '@codemirror/state';
+import {
+  Decoration,
+  DecorationSet,
+  EditorView,
+  WidgetType,
+} from '@codemirror/view';
+
+// ── State Effects ─────────────────────────────────────────────────────────────
+
+interface DiffState {
+  from: number;
+  to: number;
+  newText: string;
+}
+
+const showDiffEffect = StateEffect.define<DiffState>();
+const clearDiffEffect = StateEffect.define<void>();
+
+// ── New Text Widget ───────────────────────────────────────────────────────────
+
+class DiffNewTextWidget extends WidgetType {
+  constructor(private text: string) {
+    super();
+  }
+
+  eq(other: DiffNewTextWidget): boolean {
+    return other.text === this.text;
+  }
+
+  toDOM(): HTMLElement {
+    const el = document.createElement('div');
+    el.className = 'copilot-diff-new-text';
+    el.textContent = this.text;
+    return el;
+  }
+}
+
+// ── StateField for Diff Decorations ───────────────────────────────────────────
+
+export const inlineDiffField = StateField.define<DecorationSet>({
+  create() {
+    return Decoration.none;
+  },
+  update(value, tr) {
+    value = value.map(tr.changes);
+
+    for (const effect of tr.effects) {
+      if (effect.is(showDiffEffect)) {
+        const { from, to, newText } = effect.value;
+        const builder = new RangeSetBuilder<Decoration>();
+        if (from < to) {
+          builder.add(
+            from,
+            to,
+            Decoration.mark({ class: 'copilot-diff-old-text' }),
+          );
+        }
+        builder.add(
+          to,
+          to,
+          Decoration.widget({
+            widget: new DiffNewTextWidget(newText),
+            side: 1,
+            block: true,
+          }),
+        );
+        value = builder.finish();
+      }
+      if (effect.is(clearDiffEffect)) {
+        value = Decoration.none;
+      }
+    }
+
+    return value;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// ── Diff Toolbar ──────────────────────────────────────────────────────────────
+
+class DiffToolbar {
+  private container: HTMLElement;
+  private keydownHandler: (e: KeyboardEvent) => void;
+
+  constructor(
+    private editorView: EditorView,
+    diffFrom: number,
+    private onKeep: () => void,
+    private onUndo: () => void,
+  ) {
+    this.container = document.createElement('div');
+    this.container.className = 'copilot-diff-toolbar';
+
+    // Keep button
+    const keepBtn = document.createElement('button');
+    keepBtn.className = 'copilot-diff-toolbar-btn copilot-diff-keep';
+    keepBtn.innerHTML = 'Keep <span class="copilot-diff-shortcut">Tab</span>';
+    keepBtn.addEventListener('click', () => this.handleKeep());
+
+    // Undo button
+    const undoBtn = document.createElement('button');
+    undoBtn.className = 'copilot-diff-toolbar-btn copilot-diff-undo';
+    undoBtn.innerHTML = 'Undo <span class="copilot-diff-shortcut">Esc</span>';
+    undoBtn.addEventListener('click', () => this.handleUndo());
+
+    this.container.appendChild(keepBtn);
+    this.container.appendChild(undoBtn);
+
+    // Position above the diff start
+    const coords = editorView.coordsAtPos(diffFrom);
+    if (coords) {
+      const parentRect = editorView.dom.getBoundingClientRect();
+      this.container.style.bottom = `${parentRect.bottom - coords.top + 4}px`;
+      this.container.style.left = `${coords.left - parentRect.left}px`;
+    }
+
+    // Capture-phase keydown to intercept before the global Escape handler
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Tab' || e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        this.handleKeep();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        e.stopPropagation();
+        this.handleUndo();
+      }
+    };
+    document.addEventListener('keydown', this.keydownHandler, true);
+  }
+
+  show(): void {
+    this.editorView.dom.appendChild(this.container);
+  }
+
+  dismiss(): void {
+    document.removeEventListener('keydown', this.keydownHandler, true);
+    this.container.remove();
+  }
+
+  private handleKeep(): void {
+    this.dismiss();
+    this.onKeep();
+  }
+
+  private handleUndo(): void {
+    this.dismiss();
+    this.onUndo();
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Shows an inline diff (old text with strikethrough + new text as green block)
+ * and a floating toolbar with Keep/Undo buttons.
+ *
+ * Returns a promise that resolves to 'keep' or 'undo' based on user choice.
+ * Only used for replace-mode inline edits.
+ */
+export function showInlineDiff(
+  editorView: EditorView,
+  from: number,
+  to: number,
+  newText: string,
+): Promise<'keep' | 'undo'> {
+  return new Promise((resolve) => {
+    // Show diff decorations
+    editorView.dispatch({
+      effects: showDiffEffect.of({ from, to, newText }),
+    });
+
+    const cleanup = (decision: 'keep' | 'undo') => {
+      editorView.dispatch({ effects: clearDiffEffect.of(undefined) });
+      resolve(decision);
+    };
+
+    // Create and show toolbar
+    const toolbar = new DiffToolbar(
+      editorView,
+      from,
+      () => cleanup('keep'),
+      () => cleanup('undo'),
+    );
+    toolbar.show();
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,6 +171,7 @@ class CopilotActionModal extends FuzzySuggestModal<CopilotAction> {
 export default class CopilotPlugin extends Plugin {
   settings!: CopilotPluginSettings;
   copilotClient: CopilotClient | null = null;
+  availableModels: { id: string; name: string }[] = [];
   private abortControllers: AbortController[] = [];
   private escapeHandler: (event: KeyboardEvent) => void;
   private activeInlineEditPopup: InlineEditPopup | null = null;
@@ -244,9 +245,12 @@ export default class CopilotPlugin extends Plugin {
         await this.copilotClient.start();
         console.log('Copilot client started successfully');
 
-        // Verify connection by fetching models
+        // Fetch and cache available models
         const models = await this.copilotClient.listModels();
-        console.log('Successfully fetched models:', models.length);
+        this.availableModels = models
+          .filter((m: any) => !m.policy || m.policy.state !== 'disabled')
+          .map((m: any) => ({ id: m.id, name: m.name }));
+        console.log('Successfully fetched models:', this.availableModels.length);
         new Notice('GitHub Copilot initialized successfully');
       }
     } catch (error) {
@@ -380,7 +384,9 @@ export default class CopilotPlugin extends Plugin {
       editorView,
       cursorFrom,
       cursorTo,
-      (instruction: string, mode: InlineEditMode) => {
+      this.availableModels,
+      this.settings.defaultModel,
+      (instruction: string, mode: InlineEditMode, model: string) => {
         popup.dismiss();
         this.activeInlineEditPopup = null;
 
@@ -394,6 +400,7 @@ export default class CopilotPlugin extends Plugin {
           ].join('\n'),
           prompt: instruction,
           replaceSelection: mode === 'replace',
+          model: model,
         };
         void this.executeAction(editor, action);
       },

--- a/styles.css
+++ b/styles.css
@@ -73,6 +73,99 @@
   }
 }
 
+/* ── Inline Diff View ──────────────────────────────────────────────────────── */
+
+/* Old text: strikethrough with red tint */
+.copilot-diff-old-text {
+  text-decoration: line-through;
+  text-decoration-color: var(--text-error);
+  background-color: rgba(255, 0, 0, 0.08);
+  color: var(--text-error);
+  border-radius: 2px;
+}
+
+/* New text: green highlighted block */
+.copilot-diff-new-text {
+  display: block;
+  white-space: pre-wrap;
+  word-break: break-word;
+  background-color: rgba(0, 180, 0, 0.08);
+  color: var(--text-success, #4caf50);
+  border-left: 3px solid var(--text-success, #4caf50);
+  padding: 4px 8px;
+  margin: 4px 0;
+  border-radius: 0 var(--radius-s) var(--radius-s) 0;
+  animation: copilot-diff-reveal 300ms ease-out;
+}
+
+@keyframes copilot-diff-reveal {
+  from {
+    opacity: 0;
+    max-height: 0;
+  }
+  to {
+    opacity: 1;
+    max-height: 1000px;
+  }
+}
+
+/* Floating diff toolbar (Keep/Undo) */
+.copilot-diff-toolbar {
+  position: absolute;
+  z-index: 100;
+  display: flex;
+  gap: var(--size-4-2);
+  padding: var(--size-2-2) var(--size-4-2);
+  background: var(--background-primary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  box-shadow: var(--shadow-s);
+  animation: copilot-message-in 150ms ease-out;
+}
+
+.copilot-diff-toolbar-btn {
+  padding: var(--size-2-1) var(--size-4-3);
+  font-size: var(--font-ui-small);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+  font-weight: var(--font-semibold);
+  transition: all var(--anim-duration-fast);
+}
+
+.copilot-diff-toolbar-btn.copilot-diff-keep {
+  background: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: var(--interactive-accent);
+}
+
+.copilot-diff-toolbar-btn.copilot-diff-keep:hover {
+  background: var(--interactive-accent-hover);
+  border-color: var(--interactive-accent-hover);
+}
+
+.copilot-diff-toolbar-btn.copilot-diff-undo {
+  background: var(--background-primary-alt);
+  color: var(--text-muted);
+}
+
+.copilot-diff-toolbar-btn.copilot-diff-undo:hover {
+  background: var(--background-modifier-border-hover);
+  color: var(--text-normal);
+}
+
+.copilot-diff-shortcut {
+  font-size: var(--font-ui-smaller);
+  color: var(--text-faint);
+  margin-left: var(--size-2-1);
+  opacity: 0.7;
+}
+
+.copilot-diff-keep .copilot-diff-shortcut {
+  color: var(--text-on-accent);
+  opacity: 0.6;
+}
+
 /* ── Inline Edit Popup ─────────────────────────────────────────────────────── */
 
 .copilot-inline-edit-popup {

--- a/styles.css
+++ b/styles.css
@@ -160,6 +160,49 @@
   opacity: 0.6;
 }
 
+/* ── Model Selector (shared) ───────────────────────────────────────────────── */
+
+.copilot-model-select {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--background-primary-alt);
+  color: var(--text-faint);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-s);
+  padding: 2px 20px 2px 6px;
+  font-size: var(--font-ui-smaller);
+  font-family: var(--font-interface);
+  cursor: pointer;
+  transition: border-color var(--anim-duration-fast), color var(--anim-duration-fast);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 5px center;
+  max-width: 160px;
+  text-overflow: ellipsis;
+}
+
+.copilot-model-select:hover {
+  color: var(--text-muted);
+  border-color: var(--background-modifier-border-hover);
+}
+
+.copilot-model-select:focus {
+  outline: none;
+  border-color: var(--interactive-accent);
+  color: var(--text-normal);
+}
+
+/* Chat: model selector row below input */
+.copilot-chat-model-row {
+  display: flex;
+  align-items: center;
+}
+
+/* Inline edit: model selector sits alongside mode buttons, right-aligned */
+.copilot-inline-edit-mode-row .copilot-model-select {
+  margin-left: auto;
+}
+
 /* ── Inline Edit Popup ─────────────────────────────────────────────────────── */
 
 .copilot-inline-edit-popup {
@@ -217,6 +260,7 @@
 .copilot-inline-edit-mode-row {
   display: flex;
   gap: var(--size-2-1);
+  align-items: center;
 }
 
 .copilot-inline-edit-mode-btn {

--- a/styles.css
+++ b/styles.css
@@ -84,9 +84,13 @@
   border-radius: 2px;
 }
 
+/* Diff review wrapper (new text + toolbar) */
+.copilot-diff-review {
+  animation: copilot-diff-reveal 300ms ease-out;
+}
+
 /* New text: green highlighted block */
 .copilot-diff-new-text {
-  display: block;
   white-space: pre-wrap;
   word-break: break-word;
   background-color: rgba(0, 180, 0, 0.08);
@@ -95,32 +99,22 @@
   padding: 4px 8px;
   margin: 4px 0;
   border-radius: 0 var(--radius-s) var(--radius-s) 0;
-  animation: copilot-diff-reveal 300ms ease-out;
 }
 
 @keyframes copilot-diff-reveal {
   from {
     opacity: 0;
-    max-height: 0;
   }
   to {
     opacity: 1;
-    max-height: 1000px;
   }
 }
 
-/* Floating diff toolbar (Keep/Undo) */
+/* Inline diff toolbar (Keep/Undo) — flows with content */
 .copilot-diff-toolbar {
-  position: absolute;
-  z-index: 100;
   display: flex;
   gap: var(--size-4-2);
-  padding: var(--size-2-2) var(--size-4-2);
-  background: var(--background-primary);
-  border: 1px solid var(--background-modifier-border);
-  border-radius: var(--radius-m);
-  box-shadow: var(--shadow-s);
-  animation: copilot-message-in 150ms ease-out;
+  padding: var(--size-2-2) 0;
 }
 
 .copilot-diff-toolbar-btn {


### PR DESCRIPTION
## Summary

**Version bump:** 1.3.0 → 1.3.1 (patch)

### Changes since v1.3.0

- **Inline diff view with Keep/Undo toolbar** — After streaming completes in Replace mode, shows a VS Code-style diff (old text in red strikethrough, new text in green) with Keep/Undo buttons that scroll with the content. Keyboard shortcuts: Tab/Enter to keep, Escape to undo.
- **Model selector in chat and inline edit** — Added a compact model dropdown to both the chat input area and the inline edit popup, allowing on-the-fly model switching without going to settings. Defaults to the configured default model, falls back to first available if the default isn't accessible.
- **New file:** `src/inlineDiffView.ts` — CM6 StateField, DiffReviewWidget, and `showInlineDiff()` API for the diff review system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)